### PR TITLE
Fixed require statements in init.lua

### DIFF
--- a/AdvTiledLoader/init.lua
+++ b/AdvTiledLoader/init.lua
@@ -2,19 +2,15 @@
 -- Add the path so lua knows where to get the files.
 TILED_LOADER_PATH = TILED_LOADER_PATH or "AdvTiledLoader/"
 
--- Get the classes
-local mapclasses = require "map"
-local loader = require "loader"
-
 -- Return the classes in a table
 return {
-		Map = require "Map",
-		TileLayer = require "TileLayer",
-		Tile = require "Tile"
-		TileSet = require "TileSet",
-		Object = require "Object",
-		ObjectLayer = require "ObjectLayer",
-		Loader = require "Loader"
+		Map = require(TILED_LOADER_PATH.."Map"),
+		TileLayer = require (TILED_LOADER_PATH.."TileLayer"),
+		Tile = require(TILED_LOADER_PATH.."Tile"),
+		TileSet = require(TILED_LOADER_PATH.."TileSet"),
+		Object = require(TILED_LOADER_PATH.."Object"),
+		ObjectLayer = require(TILED_LOADER_PATH.."ObjectLayer"),
+		Loader = require(TILED_LOADER_PATH.."Loader")
 }
 
 


### PR DESCRIPTION
Thank you for this great library! I played with it a bit but immediately encountered a problem trying to `require("AdvTiledLoader")`. It doesn't work here.

I had to fix some lines in `init.lua`: 

**Remove** these incorrect & unused require statements:

```
-- Get the classes
local mapclasses = require "map"
local loader = require "loader"
```

**Add** `TILED_LOADER_PATH..` in these require statements:

```
-- Return the classes in a table
return {
    Map = require(TILED_LOADER_PATH.."Map"),
    TileLayer = require (TILED_LOADER_PATH.."TileLayer"),
    Tile = require(TILED_LOADER_PATH.."Tile"),
    TileSet = require(TILED_LOADER_PATH.."TileSet"),
    Object = require(TILED_LOADER_PATH.."Object"),
    ObjectLayer = require(TILED_LOADER_PATH.."ObjectLayer"),
    Loader = require(TILED_LOADER_PATH.."Loader")
}
```

Regards,
Florian
