### PR TITLE
Added ellipses, change how ordering is done for tiled objects and fixed some bugs.

### DIFF
--- a/Loader.lua
+++ b/Loader.lua
@@ -486,6 +486,11 @@ function Loader._expandObjectLayer(t, map)
                     obj.polygon = {}
                     string.gsub(v2.xarg.points, "[%-%d]+", polygonFunct)
                 end
+
+		--Process ellipse objects
+		if v2.label == "ellipse" then
+		    obj.ellipse = {}
+		end
             
             end
             obj:updateDrawInfo()

--- a/Loader.lua
+++ b/Loader.lua
@@ -100,6 +100,9 @@ function Loader.save(map, filename)
     local mapx = Loader._compactMap(map)
     if not love.filesystem.exists(Loader.saveDirectory) then
         love.filesystem.mkdir(Loader.saveDirectory)
+	if not love.filesystem.exists(Loader.saveDirectory) then
+	    error("Could not create map save directory '" .. Loader.saveDirectory .. "'. \n-  Write access to '" .. love.filesystem.getSaveDirectory() .. "' denied or read only?\n-  Identity not set in 'conf.lua' or by love.filesystem.setIdentity()?")
+	end
     end
     love.filesystem.write( Loader.saveDirectory .. "/" .. filename, xml.table_to_string(mapx) )
 end
@@ -720,9 +723,14 @@ function Loader._compactObject(object)
         objectx[#objectx+1] = polygonx
     end
 
+    -- <ellipse>
+    if object.ellipse then
+	objectx[#objectx+1] = {label = "ellipse", xarg = {}}
+    end
+
     -- <properties>
     if next(object.properties) then
-        objectx[#objectx+1] = Loader.compactProperties(object.properties)
+        objectx[#objectx+1] = Loader._compactProperties(object.properties)
     end
     
     return objectx

--- a/Map.lua
+++ b/Map.lua
@@ -271,7 +271,7 @@ function Map:_updateTileRange()
                 -- Limit the drawing range. We must make sure we can draw the tiles that are bigger
                 -- than the self's tileWidth and tileHeight.
                 if x1 and y1 and x2 and y2 then
-                    x2 = ceil(x2/self.tileWidth)
+                    x2 = ceil((x2+self._widestTile-self.tileWidth)/self.tileWidth)
                     y2 = ceil((y2+heightOffset)/self.tileHeight)
                     x1 = floor((x1-widthOffset)/self.tileWidth)
                     y1 = floor(y1/self.tileHeight)


### PR DESCRIPTION
Changed the sort order of tile objects to use their bottom edge. The y coordinate of the bottom edge will also be modified by the object's 'z' property (or the tile's 'z' property if not found). 'z' is effectively how many pixels above the ground the tile object's bottom edge is.

These changes are intended to allow the use of Tiled to visually place objects and have the draw order done properly when other game objects are added to the layer.

Added support for loading, saving and displaying of ellipses. Ellipses are new to Tiled 0.9.0 (found in Tiled's Github repository). Their format is like this:

``` xml
  <object x="320" y="576" width="32" height="32">
   <ellipse/>
  </object>
```

Some bugfixes:
-   'Loader.lua' had a call to _compactProperties missing the '_'.
-   'Map.lua' didn't calculate the draw range correctly when there are extra wide tiles.
-   'Object.lua' didn't calculate the bounding box of tile objects correctly.
