### PR TITLE
Added support for map's backgroundcolor xarg

### DIFF
--- a/Loader.lua
+++ b/Loader.lua
@@ -196,11 +196,22 @@ function Loader._expandMap(name, t)
             props = Loader._expandProperties(v)
         end
     end
-    
+
+    -- Unpack background color if set
+    local bgcolor = t.xarg.backgroundcolor
+    if bgcolor then
+        bgcolor = { tonumber( "0x" .. bgcolor:sub(2,3) ),
+                    tonumber( "0x" .. bgcolor:sub(4,5) ),
+                    tonumber( "0x" .. bgcolor:sub(6,7) )}
+        assert (#bgcolor == 3 and bgcolor[1] and bgcolor[2] and bgcolor[3],
+                "Loader._expandMap - Background color is corrupt")
+    end
+
     -- Create the map from the settings
-    local map = Map:new(name, tonumber(t.xarg.width),tonumber(t.xarg.height), 
-                        tonumber(t.xarg.tilewidth), tonumber(t.xarg.tileheight), 
-                        t.xarg.orientation, props.atl_directory or fullpath, props)
+    local map = Map:new(name, tonumber(t.xarg.width),tonumber(t.xarg.height),
+                        tonumber(t.xarg.tilewidth), tonumber(t.xarg.tileheight),
+                        t.xarg.orientation, bgcolor,
+                        props.atl_directory or fullpath, props)
 
     -- Apply the loader settings if atl_useSpriteBatch or atl_drawObjects was not set
     map.useSpriteBatch = map.useSpriteBatch == nil and Loader.useSpriteBatch or map.useSpriteBatch 

--- a/Map.lua
+++ b/Map.lua
@@ -23,7 +23,7 @@ Map.__index = Map
 
 ---------------------------------------------------------------------------------------------------
 -- Returns a new map
-function Map:new(name, width, height, tileWidth, tileHeight, orientation, path, prop)
+function Map:new(name, width, height, tileWidth, tileHeight, orientation, bgcolor, path, prop)
 
     -- Our map
     local map = setmetatable({}, Map)
@@ -36,6 +36,7 @@ function Map:new(name, width, height, tileWidth, tileHeight, orientation, path, 
     map.tileWidth = tileWidth or 0                          -- Width in pixels of each tile
     map.tileHeight = tileHeight or 0                        -- Height in pixels of each tile
     map.orientation = orientation or "orthogonal"           -- Type of map. orthogonal or isometric
+    map.backgroundColor = bgcolor or { 0, 0, 0 }            -- Background color { r, g, b }
     map.properties = prop or {}                             -- Properties of the map set by Tiled
     map.useSpriteBatch = prop.atl_useSpriteBatch            -- True = TileLayers use sprite batches
     map.visible = true                                      -- False = the map will not be drawn


### PR DESCRIPTION
Tiled gives possibility to set map's background color using 'Map Properties' window. It's not set in properties though, it's argument to <map> tag. ATL lacked its support until now.
