### PR TITLE
Using tileset offsets in batch mode for isometric maps

### DIFF
--- a/TileLayer.lua
+++ b/TileLayer.lua
@@ -244,8 +244,10 @@ function TileLayer:draw()
                                     end
                                     -- Add the tile to the sprite batch.
                                     self._batches[tile.tileset]:add(tile.quad, drawX + halfW + 
+                                                                tile.tileset.offsetX +
                                                                 (rot and halfW or 0), 
-                                                                drawY-halfH+(rot and halfW or 0), 
+                                                                drawY-halfH+tile.tileset.offsetY +
+                                                                (rot and halfW or 0), 
                                                                 rot and math.pi*1.5 or 0, 
                                                                 flipX, flipY, halfW, halfH)
                                                                     


### PR DESCRIPTION
Tileset offsets has not been used in batch mode. Here is the fix for isometric maps. (It seems like orthogonal maps has this issue too, but I leave it as is).
